### PR TITLE
move socket connects into functions

### DIFF
--- a/examples/playground/example.scm
+++ b/examples/playground/example.scm
@@ -1,4 +1,4 @@
-#!/usr/bin/guile
+#!/usr/bin/env guile
 !#
 
 ;; assuming your are running from a path relative to swaypic & modules
@@ -25,14 +25,15 @@
              (ice-9 pretty-print)
              (swayipc))
 
+(SWAY-CONNECT-SOCKTES!)
 
 ;; get focused workspace from a list of workspaces
 (define (focused-workspace-name workspaces)
   (cond
-    ((null? workspaces) #f)
-    ((equal? #t (sway-workspace-focused (car workspaces)))
-     (sway-workspace-name (car workspaces)))
-    (else (focused-workspace-name (cdr workspaces)))))
+   ((null? workspaces) #f)
+   ((equal? #t (sway-workspace-focused (car workspaces)))
+    (sway-workspace-name (car workspaces)))
+   (else (focused-workspace-name (cdr workspaces)))))
 
 (format #t "output record from function #sway-get-workspaces:\n ~a\n"
         (sway-get-workspaces)) 

--- a/swayipc/connection.scm
+++ b/swayipc/connection.scm
@@ -38,6 +38,7 @@
 
             SWAY-SOCKET-PATH
             SWAY-COMMAND-SOCKET
+            SWAY-CONNECT-SOCKETS!
             SWAY-LISTENER-SOCKET
             SWAY-LISTENER-THREAD
             SWAY-MSG-MAGIC
@@ -96,12 +97,14 @@
 ;; sway listen socket, this is used to listen to subscribed events
 ;; from sway via IPC.
 (define SWAY-LISTENER-SOCKET (socket AF_UNIX SOCK_STREAM 0))
-(connect SWAY-LISTENER-SOCKET (make-socket-address AF_UNIX SWAY-SOCKET-PATH))
 
 ;; sway command socket, this is used to send commands and queries
 ;; to sway via IPC.
 (define SWAY-COMMAND-SOCKET (socket AF_UNIX SOCK_STREAM 0))
-(connect SWAY-COMMAND-SOCKET (make-socket-address AF_UNIX SWAY-SOCKET-PATH))
+
+(define (SWAY-CONNECT-SOCKETS!)
+  (connect SWAY-LISTENER-SOCKET (make-socket-address AF_UNIX SWAY-SOCKET-PATH))
+  (connect SWAY-COMMAND-SOCKET (make-socket-address AF_UNIX SWAY-SOCKET-PATH)))
 
 ;; Hashtable of mutexes for synchronization, keeps each socket separate.
 ;; This is important to lock sockets while reading/writing.


### PR DESCRIPTION
The listener and command sockets are connected to in the `(swayipc connection)` module itself, but those sockets might not be open when the module is loaded. This commit puts them into a public function, so that they can be connected to explicitly at a point where the sockets are known to be open (such as in the users actual init.scm).

This was the only problem when trying to resolve #1 and create the guix package, as the `SWAY-SOCKET-PATH` is not set in the build env (which I believe is good behavior, as sway and these modules should be independent).

Once this is resolved I can create another pull request with the guix package definition, and then if that looks good it can be submitted to the official guix repo.