### PR TITLE
add guix package

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@ You can retrieve information about =Sway=, such as list of available =workspaces
         (focused-workspace-name (sway-get-workspaces)))
 #+end_src
 
-Note: To send commands to Sway, you must connect to the Sway sockets. Without connecting to the socket your commands won't be sent to Sway. use the function =(SWAY-CONNECT-SOCKTES!)= immediately after the imports in your =init.scm= to ensure that the rest of the expressions can successfully send commands to Sway.
+Note: To send commands to Sway, you must connect to the Sway sockets. Without connecting to the socket your commands won't be sent to Sway. use the function =(sway-connect-socktes!)= immediately after the imports in your =init.scm= to ensure that the rest of the expressions can successfully send commands to Sway.
 
 #+begin_src scheme
   ;; connect to sway sockets

--- a/manifest.scm
+++ b/manifest.scm
@@ -1,0 +1,28 @@
+(use-modules (guix build-system guile)
+             (guix gexp)
+             (guix git-download)
+             ((guix licenses) #:prefix license:)
+             (guix packages)
+             (guix profiles)
+             (gnu packages)
+             (gnu packages guile))
+
+(define-public guile-swayer
+  (package
+    (name "guile-swayer")
+    (version "0.2.0")
+    (home-page "https://github.com/ebeem/guile-swayer")
+    (source
+     (origin
+       (method git-fetch)
+       (uri (git-reference
+             (url "https://github.com/ebeem/guile-swayer")
+             (commit "9c962281f405453fb3770dd0546ef6951c9236dd")))
+       (sha256 (base32 "09c0143q9sm75xp1qz7a7ihdqfwqg4w8nlq0mmnivhvamww775ss"))))
+    (native-inputs (list guile-3.0))
+    (build-system guile-build-system)
+    (synopsis "Extensible Guile bindings for SwayWM")
+    (description "Extensible Guile bindings for SwayWM")
+    (license license:expat)))
+
+(packages->manifest (list guile-3.0 guile-swayer))


### PR DESCRIPTION
Here is the guix package definition.

Until it's upstreamed into the official guix repo, people who have guix installed can clone the repo and use `guix shell` or `guix install` to run/install it. This isn't really necessary at this stage since if they've already cloned the repo they can just run it from there, but this way they can have it as part of their guile environment.