### PR TITLE
swayipc: Add missing fields for sway-output.

### DIFF
--- a/swayipc/records.scm
+++ b/swayipc/records.scm
@@ -37,13 +37,16 @@
             sway-output-model
             sway-output-serial
             sway-output-active
+            sway-output-power
             sway-output-primary
+            sway-output-focused
             sway-output-scale
             sway-output-subpixel-hinting
             sway-output-transform
             sway-output-current-workspace
             sway-output-modes
             sway-output-current-mode
+            sway-output-rect
 
             <sway-window-property>
             scm->sway-window-property
@@ -299,13 +302,16 @@
   (model)
   (serial)
   (active)
+  (power)
   (primary)
+  (focused)
   (scale)
   (subpixel-hinting "subpixel_hinting")
   (transform)
   (current-workspace "current_workspace")
   (modes "modes" #(<sway-mode>))
-  (current-mode "current_mode" <sway-mode>))
+  (current-mode "current_mode" <sway-mode>)
+  (rect "rect" <sway-rect>))
 
 (define-json-type <sway-window-property>
   (class)


### PR DESCRIPTION
I need to access the focused field of outputs, so I've added it and some other that were missing too.
`rect` and `power` are documented [here](https://github.com/swaywm/sway/blob/801bc76ce3ab2f620e30d1d0ad979caa5b03a164/sway/sway-ipc.7.scd?plain=1#L217-L246). `focsued` isn't documented (yet?) but it works as expected, its logic is [there](https://github.com/swaywm/sway/blob/801bc76ce3ab2f620e30d1d0ad979caa5b03a164/sway/ipc-server.c#L685-L693).